### PR TITLE
Add example for installing and using Kong Gateway Operator

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -62,7 +62,8 @@ export default {
                     { text: "Kong API Gateway", link: "/showcases/kong.html" },
                     { text: "Kuma Service Mesh", link: "/showcases/kuma.html" },
                     { text: "Confluent for Kubernetes", link: "/showcases/confluent.html" },
-                    { text: "Kyverno", link: "/showcases/kyverno.html" }
+                    { text: "Kyverno", link: "/showcases/kyverno.html" },
+                    { text: "Kyverno", link: "/showcases/kong-gateway-operator.html" }
                 ]
             },
             {

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -63,7 +63,7 @@ export default {
                     { text: "Kuma Service Mesh", link: "/showcases/kuma.html" },
                     { text: "Confluent for Kubernetes", link: "/showcases/confluent.html" },
                     { text: "Kyverno", link: "/showcases/kyverno.html" },
-                    { text: "Kyverno", link: "/showcases/kong-gateway-operator.html" }
+                    { text: "KOng Gateway Operator", link: "/showcases/kong-gateway-operator.html" }
                 ]
             },
             {

--- a/docs/showcases/kong-gateway-operator.md
+++ b/docs/showcases/kong-gateway-operator.md
@@ -1,0 +1,43 @@
+# Kong Gateway Operator
+
+### Precondition
+
+Cluster has to be deployed with the *NGINX Ingress Controller* and the *HTTPBin example*.
+**DNS preparation**
+
+You can test Kong Ingress by adding the following entry to your */etc/hosts* file:
+
+```bash
+# Append to /etc/hosts
+[...]
+
+127.0.0.1		httpbin.example.com
+```
+
+### Installation
+
+You can start the installation of the Kong Gateway Operator with the included shell script:
+
+```bash
+cd examples/kong-gateway-operator
+bash setup.sh
+```
+
+The following components are installed with the *setup.sh*:
+
+- Installs HashiCorp Vault for certificate management (from `examples/vault`)
+  - Installs cert-manager HELM Chart
+  - Creates a wildcard certificate for domain *example.com* - used for Kong Gateway
+- Installs Gateway API CRDs
+- Enables Kubernetes Gateway API support for cert-manager
+- Installs Kong Gateway Operator instance using Kong Operator HELM Chart (to namespace *kong-system*) - https://github.com/Kong/charts/tree/main/charts/gateway-operator
+- Configures Kong Gateway instance
+  - Creates Namespace Kong
+  - Creates GatewayClass, GatewayConfiguration and Gateway resources
+  - After that Kong Gateway is available in the namespace *kong* and can be called with the URL: https://localhost:8081
+- Creates HTTPRoute resource for the HTTPBin example
+  - After that you can open *httpbin* with the URL: https://httpbin.example.com:8081/httpbin-api/v1/anything
+
+> **NOTE**
+>
+> When you have added the Root CA to your system Truststore, or your browser the connection should be secured correctly. You can find the Root CA certificate under: `examples/vault/root-certs/rootCACert.pem`.

--- a/examples/kong-gateway-operator/gateway-configuration.yaml
+++ b/examples/kong-gateway-operator/gateway-configuration.yaml
@@ -1,0 +1,68 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: kong
+  labels:
+    kuma.io/sidecar-injection: enabled
+---
+kind: GatewayClass
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: kong
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: kong
+    namespace: kong
+---
+kind: GatewayConfiguration
+apiVersion: gateway-operator.konghq.com/v1beta1
+metadata:
+  name: kong
+  namespace: kong
+spec:
+  dataPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+            - name: proxy
+              image: kong:3.7.0
+              readinessProbe:
+                initialDelaySeconds: 1
+                periodSeconds: 1
+  controlPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+            - name: controller
+              image: kong/kubernetes-ingress-controller:3.2.0
+              env:
+                - name: CONTROLLER_LOG_LEVEL
+                  value: debug
+---
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: kong
+  namespace: kong
+  annotations:
+    cert-manager.io/cluster-issuer: "vault-issuer"
+    cert-manager.io/common-name: "kong-gateway.example.com"
+spec:
+  gatewayClassName: kong
+  listeners:
+    - name: https
+      hostname: "*.example.com"
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: example-com-tls

--- a/examples/kong-gateway-operator/httproute-httpbin.yaml
+++ b/examples/kong-gateway-operator/httproute-httpbin.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin-service
+  namespace: demo
+  annotations:
+    konghq.com/strip-path: 'true'
+spec:
+  parentRefs:
+    - name: kong
+      namespace: kong
+  hostnames:
+    - httpbin.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /httpbin-api/v1
+      backendRefs:
+        - name: httpbin
+          kind: Service
+          port: 80

--- a/examples/kong-gateway-operator/setup.sh
+++ b/examples/kong-gateway-operator/setup.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# include Hashicorp Vault setup first
+VAULT_EXISTS=$(kubectl get ns vault || echo "false")
+
+if [ "$VAULT_EXISTS" == "false" ]
+then
+cd ../vault/
+bash setup.sh
+else
+echo "Skipping vault deployment. Already there."
+fi
+
+# Remove NGINX Ingress - will be replaced with Kong Gateway resp. an Operator-based Gateway
+NGINX_EXISTS=$(kubectl get ns ingress-nginx || echo "false")
+if [ "$NGINX_EXISTS" == "false" ]
+then
+echo "Skipping deletion of NGINX ingress..."
+else
+kubectl delete -f ../../manifests/nginx-helm.yaml || true
+kubectl delete -A ValidatingWebhookConfiguration ingress-nginx-admission || true
+kubectl delete ingress -n demo httpbin
+fi
+
+echo "\nInstall Gateway API extension"
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml
+
+echo "\nUpdating cert-manager to work with Gateway API"
+helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager \
+  --set config.apiVersion="controller.config.cert-manager.io/v1alpha1" \
+  --set config.kind="ControllerConfiguration" \
+  --set config.enableGatewayAPI=true
+
+kubectl rollout restart deployment cert-manager -n cert-manager
+
+kubectl -n cert-manager wait --for=condition=Available=true --timeout=120s deployment/cert-manager
+
+cd ../kong-gateway-operator/
+
+echo "\nInstall Kong Gateway Operator"
+helm repo add kong https://charts.konghq.com
+helm repo update kong
+
+helm upgrade --install kgo kong/gateway-operator -n kong-system --create-namespace --set image.tag=1.2
+
+kubectl -n kong-system wait --for=condition=Available=true --timeout=120s deployment/kgo-gateway-operator-controller-manager
+
+kubectl apply -f gateway-configuration.yaml
+
+echo "\nConfigure HTTPRoute for httpbin"
+kubectl apply -f httproute-httpbin.yaml


### PR DESCRIPTION
I've added a new example for Kong Gateway Operator.

It uses the Vault example and installs Kong Gateway API CRDs and the Kong Gateway Operator.

In addition, a new Kong Gateway instance is configured, and the HTTPBin example service is exposed using an HTTPRoute.