### PR TITLE
fix external dns (remove bitnami)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Kong Gateway TLS passthrough (`TLSRoute`) now requires `parameters: [ssl]` on the `proxy.stream` entry in `values.yaml`. Kong KIC only recognises a stream listener as `TLSProtocolType` when the Admin API reports `SSL=true` for that listener. Without the flag KIC sets the Gateway listener to `UnsupportedProtocol` and the TLSRoute stays in `NoMatchingParent`. Documented in `docs/showcases/kong.md`.
-* Added PostgreSQL 17 TLS passthrough demo to the Kong Gateway showcase (`examples/kong-gateway/`). Demonstrates SNI-based routing of non-HTTP traffic using PostgreSQL 17 direct SSL (`sslnegotiation=direct`). Includes a cert-manager Certificate issued by Vault PKI, an init container to fix TLS key permissions, and a `TLSRoute` for `postgres.example.com`. The Gateway `kong-tls-passthrough` listener hostname widened to `*.example.com` to support multiple backends on the same listener.
-* Extended `examples/kong-gateway/setup.sh` to deploy the PostgreSQL TLS passthrough demo automatically.
-
 ### Removed
 
 ### Fixed
+
+## [1.1.1] - 2026-04-09
+
+### Fixed
+
+* Replaced deprecated Bitnami Helm chart for ExternalDNS (`bitnami/external-dns`) with the official chart (`external-dns/external-dns` from `https://kubernetes-sigs.github.io/external-dns/`). The official chart uses images from `registry.k8s.io/external-dns/external-dns` which are always accessible. Provider configuration changed from `--set provider=coredns` to `--set provider.name=coredns`; etcd endpoint is now passed via the `ETCD_URLS` environment variable.
+* Replaced Bitnami etcd Helm chart with a plain Kubernetes manifest (`etcd.yaml`) using the `registry.k8s.io/etcd:3.5.16-0` image. Bitnami images (`docker.io/bitnami/etcd`) were not pullable, causing the ExternalDNS showcase to fail entirely.
+* ExternalDNS sources are now set explicitly depending on the ingress mode: `ingress` for HAProxy, `gateway-httproute` for Kong Gateway (closes [#45](https://github.com/FabianHardt/k3d-bootstrap-cluster/issues/45)).
+
+## [1.1.0] - 2026-04-09
+
+### Added
+
+* OpenBao showcase (`examples/openbao/`) — OpenBao is an open-source fork of HashiCorp Vault maintained by the Linux Foundation after Vault's license change to BSL. The API and `bao` CLI are fully compatible with Vault. Includes automated setup script, Helm values for HAProxy and Kong Gateway, HTTPRoute/Ingress resources, and a dedicated documentation page (`docs/showcases/openbao.md`).
+* Multi-ingress support across showcases: `external-dns`, `external-secrets`, `kyverno`, and `kuma-mesh` now support both HAProxy Ingress and Kong Gateway API (HTTPRoute). The ingress mode is auto-detected from the cluster or can be forced via `HAPROXY_FLAG=Yes` / `KONG_FLAG=Yes`.
+* HTTPRoute resources for Kong Gateway added to `examples/external-dns/`, `examples/kyverno/`, and `examples/openbao/`.
+
+### Changed
+
+* Kong Gateway TLS passthrough (`TLSRoute`) now requires `parameters: [ssl]` on the `proxy.stream` entry in `values.yaml`. Kong KIC only recognises a stream listener as `TLSProtocolType` when the Admin API reports `SSL=true` for that listener. Without the flag KIC sets the Gateway listener to `UnsupportedProtocol` and the TLSRoute stays in `NoMatchingParent`. Documented in `docs/showcases/kong.md`.
+* Added PostgreSQL 17 TLS passthrough demo to the Kong Gateway showcase (`examples/kong-gateway/`). Demonstrates SNI-based routing of non-HTTP traffic using PostgreSQL 17 direct SSL (`sslnegotiation=direct`). Includes a cert-manager Certificate issued by OpenBao PKI, an init container to fix TLS key permissions, and a `TLSRoute` for `postgres.example.com`. The Gateway `kong-tls-passthrough` listener hostname widened to `*.example.com` to support multiple backends on the same listener.
+* Extended `examples/kong-gateway/setup.sh` to deploy the PostgreSQL TLS passthrough demo automatically.
+* Kong Gateway Operator: updated `GatewayConfiguration` to align with current CRD schema (`examples/kong-gateway-operator/`).
+* Kuma Mesh helpers extended with additional wait logic and improved cluster setup (`examples/kuma-mesh/helpers.sh`).
+
+### Removed
+
+* HashiCorp Vault showcase (`examples/vault/`) — replaced by the OpenBao showcase. OpenBao is a fully API-compatible drop-in replacement.
 
 ## [1.0.0] - 2026-04-05
 
@@ -153,7 +177,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added external-dns sample. Demonstrates ExternalDNS, which configures an external CoreDNS server - by @FabianHardt in https://github.com/FabianHardt/k3d-sample-cluster/pull/2
 - Added Hashicorp Vault as CA server in combination with cert-manager do demonstrate auto generated certificates - by @FabianHardt in https://github.com/FabianHardt/k3d-sample-cluster/pull/6
 
-[unreleased]: https://github.com/FabianHardt/k3d-bootstrap-cluster/compare/v1.0.0...HEAD
+[unreleased]: https://github.com/FabianHardt/k3d-bootstrap-cluster/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/FabianHardt/k3d-bootstrap-cluster/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/FabianHardt/k3d-bootstrap-cluster/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/FabianHardt/k3d-bootstrap-cluster/compare/v0.9.0...v1.0.0
 [0.9.0]: https://github.com/FabianHardt/k3d-bootstrap-cluster/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/FabianHardt/k3d-bootstrap-cluster/compare/v0.7.0...v0.8.0

--- a/docs/showcases/external-dns.md
+++ b/docs/showcases/external-dns.md
@@ -4,44 +4,51 @@
 
 Cluster has to be deployed with the *httpbin* sample. Otherwise this demo wouldn't work.
 
+### Components
+
+| Component | Source |
+|-----------|--------|
+| etcd | Plain Kubernetes manifest (`etcd.yaml`) using `registry.k8s.io/etcd:3.5.16-0` |
+| CoreDNS | Helm chart `coredns/coredns` |
+| ExternalDNS | Official Helm chart `external-dns/external-dns` (`registry.k8s.io/external-dns/external-dns`) |
+
 ### Installation
 
-With this small script an etc, coredns and ExternalDNS is installed:
-
 ```bash
-# Installation of etcd, coredns and ExternalDNS
 cd examples/external-dns
-bash setup.sh
 
-# Test DNS queries with test container
-kubectl run -it --rm --restart=Never --image=infoblox/dnstools:latest dnstools
+# With HAProxy Ingress Controller (auto-detected if not set)
+HAPROXY_FLAG=Yes bash setup.sh
 
-# Answer - should be something sililar to this:
-Name:	httpbin.example.com
-Address: 172.21.0.5
-Name:	httpbin.example.com
-Address: 172.21.0.6
-Name:	httpbin.example.com
-Address: 172.21.0.7
-Name:	httpbin.example.com
-Address: 172.21.0.4
-Name:	httpbin.example.com
-Address: 172.21.0.8
-Name:	httpbin.example.com
-Address: 172.21.0.3
+# With Kong Gateway (Gateway API / HTTPRoute)
+KONG_FLAG=Yes bash setup.sh
 ```
 
-CoreDNS will have the following config after installation - where the IP is the service IP of the etcd installation:
+If neither flag is set, the ingress mode is auto-detected from the cluster.
+
+ExternalDNS is configured with the CoreDNS provider. It watches Ingress resources (HAProxy mode) or HTTPRoutes (Kong mode) and writes DNS records into etcd, which CoreDNS serves.
+
+### How it works
+
+1. **etcd** is deployed as a single-pod Deployment — CoreDNS and ExternalDNS use it as the DNS record store.
+2. **CoreDNS** is configured with the `etcd` plugin for the `example.com` zone and exposed via NodePort `30053`.
+3. **ExternalDNS** watches Ingress/HTTPRoute resources and registers A records in etcd using the Ingress controller's LoadBalancer IP.
+4. **HAProxy Ingress Controller** must have `publishService.enabled: true` (already set in `manifests/haproxy-helm.yaml`) so that the Ingress `.status.loadBalancer` is populated — ExternalDNS reads that IP as the DNS target.
+
+### CoreDNS configuration
+
+After installation the generated ConfigMap looks like this (etcd endpoint IP varies):
 
 ```yaml
 apiVersion: v1
+kind: ConfigMap
 data:
   Corefile: |-
     .:53 {
         etcd example.com {
             stubzones
             path /skydns
-            endpoint http://10.43.60.159:2379
+            endpoint http://10.43.x.x:2379
         }
         debug
         errors
@@ -52,28 +59,36 @@ data:
         reload
         loadbalance
     }
-kind: ConfigMap
-metadata:
-  annotations:
-    meta.helm.sh/release-name: coredns
-    meta.helm.sh/release-namespace: dns-sample
-  labels:
-    app.kubernetes.io/instance: coredns
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: coredns
-    helm.sh/chart: coredns-1.19.5
-    k8s-app: coredns
-    kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: CoreDNS
-  name: coredns-coredns
-  namespace: dns-sample
 ```
 
-After successful installation DNS is exposed to your host via NodePort 30053. You can test the DNS resoltion directly on your host:
+### Test DNS resolution
+
+CoreDNS is exposed on NodePort `30053`, which k3d maps to a random host port. Look up the port with:
 
 ```bash
-# Look for the right port (external Docker port) in your Docker environment
-# "docker ps", then look for loadbalancer container
-dig @localhost httpbin.example.com -p <RANDOM PORT>
+docker ps --format '{{.Ports}}' | grep 30053
+# e.g. 0.0.0.0:49625->30053/udp
 ```
 
+Then query directly from your host:
+
+```bash
+dig @localhost httpbin.example.com -p <PORT>
+```
+
+Expected answer:
+
+```
+;; ANSWER SECTION:
+httpbin.example.com.  30  IN  A  172.25.0.4
+```
+
+The IP is the ClusterIP of the HAProxy LoadBalancer service (or Kong Gateway service in Kong mode).
+
+You can also run an in-cluster test:
+
+```bash
+kubectl run -it --rm --restart=Never --image=infoblox/dnstools:latest dnstools
+# Inside the container:
+# nslookup httpbin.example.com <coredns-service-ip>
+```

--- a/examples/external-dns/etcd.yaml
+++ b/examples/external-dns/etcd.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dns-sample
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns-etcd
+  namespace: dns-sample
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: coredns-etcd
+  template:
+    metadata:
+      labels:
+        app: coredns-etcd
+    spec:
+      containers:
+      - name: etcd
+        image: registry.k8s.io/etcd:3.5.16-0
+        command:
+        - etcd
+        - --listen-client-urls=http://0.0.0.0:2379
+        - --advertise-client-urls=http://0.0.0.0:2379
+        - --listen-peer-urls=http://0.0.0.0:2380
+        - --initial-advertise-peer-urls=http://0.0.0.0:2380
+        - --initial-cluster=default=http://0.0.0.0:2380
+        - --data-dir=/var/etcd/data
+        ports:
+        - containerPort: 2379
+          name: client
+        - containerPort: 2380
+          name: peer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-etcd
+  namespace: dns-sample
+spec:
+  selector:
+    app: coredns-etcd
+  ports:
+  - name: client
+    port: 2379
+    targetPort: 2379

--- a/examples/external-dns/setup.sh
+++ b/examples/external-dns/setup.sh
@@ -23,17 +23,35 @@ else
   INGRESS_MODE="none"
 fi
 
-helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
 helm repo add coredns https://coredns.github.io/helm
 helm repo update
-helm upgrade --install coredns-etcd bitnami/etcd --set auth.rbac.create=false --namespace dns-sample --create-namespace
-sleep 3
+
+# etcd is deployed as a plain manifest using registry.k8s.io/etcd (no Bitnami dependency)
+kubectl apply -f etcd.yaml
+kubectl rollout status deployment/coredns-etcd -n dns-sample --timeout=120s
+
 ETCD_SERVICE_IP=$(kubectl get svc -n dns-sample coredns-etcd -o jsonpath="{.spec.clusterIP}")
 
 templateConfigFile "values-template.yaml" "values.yaml"
 
 helm upgrade --install coredns coredns/coredns --values=values.yaml --namespace dns-sample --create-namespace
-helm upgrade --install external-dns bitnami/external-dns --namespace dns-sample --create-namespace --set coredns.etcdEndpoints=http://${ETCD_SERVICE_IP}:2379 --set provider=coredns
+
+# external-dns: official chart (registry.k8s.io/external-dns/external-dns image)
+# Sources depend on ingress mode: Ingress resources for HAProxy, HTTPRoutes for Kong
+if [ "${INGRESS_MODE}" == "kong" ]; then
+  EXTERNAL_DNS_SOURCES=("--set" "sources[0]=service" "--set" "sources[1]=gateway-httproute")
+else
+  EXTERNAL_DNS_SOURCES=("--set" "sources[0]=service" "--set" "sources[1]=ingress")
+fi
+
+helm upgrade --install external-dns external-dns/external-dns \
+  --namespace dns-sample --create-namespace \
+  --set provider.name=coredns \
+  --set "env[0].name=ETCD_URLS" \
+  --set "env[0].value=http://${ETCD_SERVICE_IP}:2379" \
+  --set policy=sync \
+  "${EXTERNAL_DNS_SOURCES[@]}"
 
 echo "Waiting 10 seconds!"
 sleep 10
@@ -41,6 +59,18 @@ if [ "${INGRESS_MODE}" == "haproxy" ]; then
   echo "Deploy sample ingress!"
   kubectl delete ingress -n demo httpbin || true
   kubectl apply -n demo -f update-httpbin-ingress.yaml
+
+  # k3d's klipper servicelb does not populate .status.loadBalancer on the
+  # HAProxy service, so the ingress controller cannot publish the Ingress
+  # status address. Patch it manually with the node IPs so that the
+  # controller sets Ingress .status and ExternalDNS can register the record.
+  LB_INGRESS_JSON=$(kubectl get nodes -o json | jq -c '[.items[].status.addresses[] | select(.type=="InternalIP") | {ip: .address}]')
+  kubectl patch svc haproxy-ingress -n ingress-haproxy --subresource=status --type=merge \
+    -p "{\"status\":{\"loadBalancer\":{\"ingress\":${LB_INGRESS_JSON}}}}"
+
+  # Annotate the Ingress once to trigger an immediate status reconciliation
+  kubectl annotate ingress httpbin -n demo external-dns-trigger="$(date +%s)" --overwrite
+
 elif [ "${INGRESS_MODE}" == "kong" ]; then
   echo "Deploy sample HTTPRoute!"
   kubectl apply -n demo -f httproute-httpbin.yaml

--- a/examples/kong-gateway/helpers.sh
+++ b/examples/kong-gateway/helpers.sh
@@ -2,14 +2,26 @@
 
 LICENSE_FILE=license.json
 
+KONG_INGRESS_CHART_VERSION=0.24.0
+# kong/kong sub-chart version bundled in kong/ingress ${KONG_INGRESS_CHART_VERSION}
+KONG_SUBCHART_VERSION=3.2.0
+
 installIngressController() {
 	# Preconditions
 kubectl create namespace kong || true
 
+# Helm only auto-installs CRDs from the top-level chart's crds/ directory.
+# kong/ingress has no crds/ directory — the configuration.konghq.com CRDs live
+# in the bundled kong/kong sub-chart and must be applied explicitly.
+TMPDIR=$(mktemp -d)
+helm pull kong/kong --version "${KONG_SUBCHART_VERSION}" --untar --untardir "${TMPDIR}"
+kubectl apply -f "${TMPDIR}/kong/crds/"
+rm -rf "${TMPDIR}"
+
 kubectl apply -f gateway-class.yaml
 kubectl apply -f gateway.yaml
 
-helm upgrade --install kong kong/ingress --values values.yaml --namespace kong
+helm upgrade --install kong kong/ingress --version "${KONG_INGRESS_CHART_VERSION}" --values values.yaml --namespace kong
 
 if [[ -f ${LICENSE_FILE} ]]; then
 echo "${LICENSE_FILE} exists. Using it!"

--- a/helpers.sh
+++ b/helpers.sh
@@ -115,14 +115,22 @@ deployKong()
   kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
 
   kubectl create namespace kong || true
+
+  # The kong/ingress chart bundles kong/kong as a sub-chart whose crds/ directory
+  # Helm does not auto-install (Helm only processes crds/ from the top-level chart).
+  # Install them explicitly from the matching sub-chart version.
+  KONG_SUBCHART_TMPDIR=$(mktemp -d)
+  helm pull kong/kong --version 3.2.0 --untar --untardir "${KONG_SUBCHART_TMPDIR}"
+  kubectl apply -f "${KONG_SUBCHART_TMPDIR}/kong/crds/"
+  rm -rf "${KONG_SUBCHART_TMPDIR}"
+
   kubectl apply -f manifests/kong-gateway-class.yaml
   kubectl apply -f manifests/kong-gateway.yaml
 
   helm upgrade --install kong kong/ingress \
     --namespace kong \
     --version 0.24.0 \
-    --values manifests/kong-values.yaml \
-    --skip-crds
+    --values manifests/kong-values.yaml
 
   kubectl -n kong wait --for=condition=Available=true --timeout=300s deployment/kong-gateway
 

--- a/manifests/haproxy-helm.yaml
+++ b/manifests/haproxy-helm.yaml
@@ -25,5 +25,7 @@ spec:
   valuesContent: |-
     controller:
       ingressClass: haproxy
+      publishService:
+        enabled: true
       config:
         use-forwarded-headers: "true"


### PR DESCRIPTION
## Description

Fixes #45 
This pull request introduces significant improvements to the ExternalDNS showcase, multi-ingress support, and the OpenBao showcase, while also updating dependencies and documentation for better reliability and maintainability. The most important changes are grouped below.

---

**ExternalDNS and etcd Improvements**

* Migrated from the deprecated Bitnami Helm charts for both ExternalDNS and etcd to the official ExternalDNS chart (`external-dns/external-dns`) and a plain Kubernetes manifest for etcd using the `registry.k8s.io/etcd:3.5.16-0` image. This resolves prior image pull issues and ensures long-term accessibility. Provider configuration and etcd endpoint setup have been updated accordingly. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R44) [[2]](diffhunk://#diff-48f703b564e85f62922fa14c9664697702a3aff657b6107d3c9696c6451e4277R1-R49) [[3]](diffhunk://#diff-4a5d97ac3311152835045d7460d4f2b78c2f19f8b837e92407bf55732fcbfc92L26-R73)
* The ExternalDNS setup now explicitly configures sources based on the ingress mode: `ingress` for HAProxy and `gateway-httproute` for Kong Gateway, addressing prior issues with source detection and registration. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R44) [[2]](diffhunk://#diff-4a5d97ac3311152835045d7460d4f2b78c2f19f8b837e92407bf55732fcbfc92L26-R73)
* Documentation for the ExternalDNS showcase has been rewritten and expanded to reflect the new architecture, installation steps, and testing procedures. [[1]](diffhunk://#diff-1cfb318e421d8fc4e2311518dd649fb4fae65599932afef2ed07bcc4707b5d4bL7-R51) [[2]](diffhunk://#diff-1cfb318e421d8fc4e2311518dd649fb4fae65599932afef2ed07bcc4707b5d4bL55-R94)

**Multi-Ingress and Showcase Enhancements**

* Added multi-ingress support to all relevant showcases (`external-dns`, `external-secrets`, `kyverno`, `kuma-mesh`), with automatic detection or manual override for HAProxy and Kong Gateway modes. HTTPRoute resources for Kong have been added to multiple examples.
* Introduced the OpenBao showcase as a replacement for the HashiCorp Vault showcase, following Vault’s license change. OpenBao is API-compatible and includes setup scripts, Helm values, and documentation.

**Kong Gateway and Kuma Mesh Updates**

* Updated Kong Gateway Operator configuration to match the latest CRD schema and improved TLS passthrough demo to use OpenBao PKI.
* Enhanced Kuma Mesh helpers with improved wait logic and cluster setup.

**Dependency and Version Management**

* Updated Helm chart references and versions for Kong Gateway and its sub-charts, and ensured CRDs are installed correctly by explicitly applying them from the sub-chart.
* Updated changelog links and version tags to reflect the new releases.

**Miscellaneous**

* Enabled `publishService` in the HAProxy Helm values to ensure correct population of Ingress status, which is required for ExternalDNS to function properly.
* The HashiCorp Vault showcase has been removed in favor of OpenBao.

---

These changes collectively improve the reliability, maintainability, and clarity of the project’s ingress and DNS infrastructure, as well as its documentation and showcase coverage.

## Type of change

- [x] Bug fix
- [ ] New feature / showcase
- [x] Documentation update
- [ ] Dependency update
- [ ] Other

## Testing

Follow the example/external-dns instructions.

- [x] Ran `bash create-sample.sh` successfully
- [x] Tested the affected example(s) end-to-end

## Checklist

- [x] CHANGELOG.md updated under `[Unreleased]`
- [x] Documentation updated (if applicable)
