### PR TITLE
ci(smoke): pin nip.io hostnames to loopback on the runner

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -57,6 +57,14 @@ jobs:
             | TAG=${K3D_VERSION} bash
           k3d version
 
+      # nip.io resolution is flaky on runners; without it docker does not
+      # detect the loopback registry and refuses the plain-HTTP push
+      # ("server gave HTTP response to HTTPS client")
+      - name: Pin nip.io hostnames to loopback
+        run: |
+          echo "127.0.0.1 registry-demo.127-0-0-1.nip.io demo.127-0-0-1.nip.io dashboard.127-0-0-1.nip.io" \
+            | sudo tee -a /etc/hosts
+
       - name: Create cluster (non-interactive)
         run: env NON_INTERACTIVE=1 ${{ matrix.flags }} bash create-sample.sh
 
@@ -203,6 +211,14 @@ jobs:
           curl -fsSL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh \
             | TAG=${K3D_VERSION} bash
           k3d version
+
+      # nip.io resolution is flaky on runners; without it docker does not
+      # detect the loopback registry and refuses the plain-HTTP push
+      # ("server gave HTTP response to HTTPS client")
+      - name: Pin nip.io hostnames to loopback
+        run: |
+          echo "127.0.0.1 registry-demo.127-0-0-1.nip.io demo.127-0-0-1.nip.io dashboard.127-0-0-1.nip.io" \
+            | sudo tee -a /etc/hosts
 
       - name: Create cluster (non-interactive)
         run: env NON_INTERACTIVE=1 ${{ matrix.flags }} bash create-sample.sh


### PR DESCRIPTION
## Summary

The crossplane smoke job on #63 failed before its setup even started: the `docker push` to the local registry was refused with `server gave HTTP response to HTTPS client`. Root cause: nip.io DNS resolution is flaky on GitHub runners — when it fails, docker cannot detect that `registry-demo.127-0-0-1.nip.io` resolves to loopback and therefore does not apply its insecure-registry exception. The curl smoke checks depend on the same external resolution.

Pinning the three runner-side hostnames (`registry-demo…`, `demo…`, `dashboard…`) to `127.0.0.1` in `/etc/hosts` removes the external DNS dependency from all smoke jobs. In-cluster resolution is unaffected (k3d handles the registry name inside the nodes).

## Test plan
- [ ] smoke workflow green on this PR