### PR TITLE
fix(crossplane): point defaultCompositionRef at the kong composition

### DIFF
--- a/examples/crossplane/platform/03-xrd.yaml
+++ b/examples/crossplane/platform/03-xrd.yaml
@@ -21,7 +21,7 @@ spec:
     kind: AppEnvironment
     plural: appenvironments
   defaultCompositionRef:
-    name: appenvironment-haproxy
+    name: appenvironment-kong
   versions:
     - name: v1alpha1
       served: true


### PR DESCRIPTION
## Summary

`platform/03-xrd.yaml` still referenced the `appenvironment-haproxy` composition that #59 removed. The XR therefore selected a non-existent composition (`cannot fetch Composition` events) and `appenvironment/meine-app` never became Ready. The crossplane smoke job has been red since the Kong-only merge — the setup script masks the failure locally because its claim wait is softened with a hint text; the CI verify step caught it.

## Test plan
- [ ] crossplane smoke job green on this PR