### PR TITLE
kong-gateway-operator: migrate to kong/kong-operator chart (closes #70)

### DIFF
--- a/examples/kong-gateway-operator/gateway-configuration.yaml
+++ b/examples/kong-gateway-operator/gateway-configuration.yaml
@@ -39,7 +39,8 @@ spec:
         spec:
           containers:
             - name: controller
-              image: kong/kubernetes-ingress-controller:3.4
+              # __KONG_KIC_VERSION__ is replaced by setup.sh from kong-versions.env
+              image: kong/kubernetes-ingress-controller:__KONG_KIC_VERSION__
               env:
                 - name: CONTROLLER_LOG_LEVEL
                   value: debug

--- a/examples/kong-gateway-operator/gateway-configuration.yaml
+++ b/examples/kong-gateway-operator/gateway-configuration.yaml
@@ -50,9 +50,11 @@ apiVersion: gateway.networking.k8s.io/v1
 metadata:
   name: kong
   namespace: kong
-  annotations:
-    cert-manager.io/cluster-issuer: "openbao-issuer"
-    cert-manager.io/common-name: "kong-gateway.example.com"
+  # No cert-manager.io annotations here: OpenBao's setup (run first) already issues
+  # the example-com-wildcard Certificate for *.example.com into the example-com-tls
+  # secret. Annotating the Gateway would make cert-manager's gateway-shim create a
+  # second Certificate pointing at the same secret — a conflict that leaves the
+  # HTTPS listener unresolved. We just reference the OpenBao-provided secret below.
 spec:
   gatewayClassName: kong
   listeners:

--- a/examples/kong-gateway-operator/setup.sh
+++ b/examples/kong-gateway-operator/setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Kong component versions (chart + KIC) come from the central kong-versions.env.
+source "$(dirname "${BASH_SOURCE[0]}")/../../kong-versions.env"
+
 # include OpenBao setup first
 OPENBAO_EXISTS=$(kubectl get ns openbao || echo "false")
 
@@ -42,13 +45,31 @@ echo "\nInstall Kong Gateway Operator"
 helm repo add kong https://charts.konghq.com
 helm repo update kong
 
-helm upgrade --install kgo kong/gateway-operator -n kong-system --create-namespace --reset-values
+# The base cluster ships KIC-managed Kong (create-sample's deployKong, Helm release
+# "kong"); the Kong Operator manages its OWN Kong and its unified chart owns the same
+# configuration.konghq.com CRDs. Unlike the legacy gateway-operator chart (CRDs in
+# crds/, silently skipped if present), the new chart renders them as owned templates,
+# so Helm refuses to adopt the KIC-owned CRDs ("invalid ownership metadata"). Remove
+# the KIC install first — no Kong CRs exist yet on a fresh cluster, so this is safe.
+helm uninstall kong -n kong 2>/dev/null || true
+kubectl get crd -o name 2>/dev/null | grep 'configuration.konghq.com$' | xargs -r kubectl delete --ignore-not-found
 
-kubectl -n kong-system wait --for=condition=Available=true --timeout=120s deployment/kgo-gateway-operator-controller-manager
+# We install the Gateway API CRDs ourselves (experimental channel, above), so
+# disable the chart's own Gateway API CRD install — otherwise its server-side apply
+# conflicts with ours ("conflict ... gateway.networking.k8s.io/channel") and the
+# whole helm install aborts. The KO conversion webhook (enabled by default) keeps
+# the deprecated GatewayConfiguration v1beta1 appliable.
+helm upgrade --install kgo kong/kong-operator --version "${KONG_OPERATOR_CHART_VERSION}" \
+  -n kong-system --create-namespace --reset-values \
+  --set gwapi-standard-crds.enabled=false \
+  --set gwapi-experimental-crds.enabled=false
+
+kubectl -n kong-system wait --for=condition=Available=true --timeout=120s deployment/kgo-kong-operator-controller-manager
 
 # GatewayClass "kong" may already exist from kong-gateway example with a different controllerName — recreate it
 kubectl delete gatewayclass kong --ignore-not-found
-kubectl apply -f gateway-configuration.yaml
+# Inject the central KIC version into the control-plane image before applying.
+sed "s|__KONG_KIC_VERSION__|${KONG_KIC_VERSION}|" gateway-configuration.yaml | kubectl apply -f -
 
 echo "\nConfigure HTTPRoute for httpbin"
 kubectl apply -f httproute-httpbin.yaml

--- a/examples/openbao/setup.sh
+++ b/examples/openbao/setup.sh
@@ -118,6 +118,15 @@ metadata:
   namespace: kong
 spec:
   secretName: example-com-tls
+  # Label the generated secret with konghq.com/secret=true so the Kong Operator's
+  # embedded ControlPlane (kong-gateway-operator example) caches it — its Secret
+  # informer is label-filtered, and without this the Gateway HTTPS listener fails
+  # with 'getGatewayCerts: Secret not found'. Harmless for the KIC-based examples.
+  # secretTemplate (not a manual kubectl label) because cert-manager strips labels
+  # it does not manage on every (re)issue.
+  secretTemplate:
+    labels:
+      konghq.com/secret: "true"
   issuerRef:
     kind: ClusterIssuer
     name: openbao-issuer

--- a/examples/openbao/setup.sh
+++ b/examples/openbao/setup.sh
@@ -126,7 +126,7 @@ spec:
   # it does not manage on every (re)issue.
   secretTemplate:
     labels:
-      konghq.com/secret: "true"
+      konghq.com/secret: 'true'
   issuerRef:
     kind: ClusterIssuer
     name: openbao-issuer

--- a/kong-versions.env
+++ b/kong-versions.env
@@ -9,3 +9,6 @@
 KONG_GATEWAY_VERSION=3.14.0.8
 KONG_KIC_VERSION=3.5.10
 KONG_INGRESS_CHART_VERSION=0.24.0
+# Kong Operator Helm chart (kong/kong-operator, formerly kong/gateway-operator).
+# Used by examples/kong-gateway-operator.
+KONG_OPERATOR_CHART_VERSION=1.3.1


### PR DESCRIPTION
Closes #70.

## Summary

Migrate `examples/kong-gateway-operator` from the legacy, unpinned
`kong/gateway-operator` chart to the renamed, unified **`kong/kong-operator`**
(1.3.1 / appVersion 2.2.2), pinned via `kong-versions.env`, and align KIC with the
central version. Verified live end to end on a fresh cluster, including an HTTP 200
through the operator-provisioned Gateway.

## Changes

- **kong-versions.env**: add `KONG_OPERATOR_CHART_VERSION=1.3.1`.
- **kong-gateway-operator/setup.sh**: source `kong-versions.env`; install
  `kong/kong-operator --version ${KONG_OPERATOR_CHART_VERSION}`; fix the readiness
  wait to the new deployment name (`kgo-kong-operator-controller-manager`); inject
  `${KONG_KIC_VERSION}` into the control-plane image.
- **kong-gateway-operator/gateway-configuration.yaml**: control-plane KIC image
  `3.4` → central `3.5.10` (placeholder); `GatewayConfiguration` stays `v1beta1`
  (still served on 2.x via the conversion webhook; storage is now `v2beta1`); drop
  the Gateway's `cert-manager.io/*` annotations (see cert fix below).
- **openbao/setup.sh**: label the wildcard TLS secret `konghq.com/secret=true` via
  the Certificate's `secretTemplate` (see cert fix below).

## Migration was not a drop-in — three conflicts the new chart surfaced

1. **Bundled Gateway API CRDs**: the new chart installs Gateway API CRDs as owned
   templates and its server-side apply conflicts with the experimental channel the
   example installs itself (`gateway.networking.k8s.io/channel`), aborting the helm
   install. Disabled via `--set gwapi-standard-crds.enabled=false
   --set gwapi-experimental-crds.enabled=false`.
2. **CRD ownership vs the base KIC Kong**: unlike the legacy chart (CRDs under
   `crds/`, skipped if present), the new chart renders `configuration.konghq.com`
   CRDs as owned templates, so Helm refuses to adopt the ones the base cluster's
   KIC-managed Kong already owns. The operator manages its own Kong, so we remove
   the KIC install first (no Kong CRs exist on a fresh cluster).
3. **TLS secret invisible to the embedded ControlPlane**: KO 2.x's embedded
   ControlPlane caches Secrets through a label-filtered informer
   (`konghq.com/secret=true`); a cert-manager secret without that label logs
   `getGatewayCerts: Secret not found` and the HTTPS listener never resolves. Fixed
   by stamping the label via `secretTemplate` (a manual `kubectl label` does not
   survive cert-manager re-issues). Also dropped the duplicate `example-com-tls`
   Certificate the Gateway shim created (OpenBao already provisions that secret).

## Verification (fresh cluster, live)

| Check | Result |
|---|---|
| `kong/kong-operator` 1.3.1 / 2.2.2 installs and runs | ✅ |
| controllerName `konghq.com/gateway-operator` unchanged → GatewayClass Accepted | ✅ |
| `GatewayConfiguration` v1beta1 applies (conversion webhook) | ✅ |
| KIC 3.5.10 as control-plane image, sourced from `kong-versions.env` | ✅ |
| Operator provisions DataPlane + ControlPlane (Ready); Gateway Programmed=True | ✅ |
| End-to-end httpbin through the operator Gateway → **HTTP 200** | ✅ |